### PR TITLE
[HOTFIX] Invalid timestamp

### DIFF
--- a/app/repositories/transactions_repository.py
+++ b/app/repositories/transactions_repository.py
@@ -51,6 +51,7 @@ class TransactionsRepository:
         try:
             transactions = Transactions(type='store', quantity=1, variation=apple.variation, automated=True,
                                         memo="IAM 시스템에 의해 자동으로 입고된 품목입니다.")
+            transactions.timestamp = datetime.now(tz=pytz.timezone('Asia/Seoul')).replace(microsecond=0)
             db.add(transactions)
             db.flush()
             product = db.query(Products).filter(Products.id == apple.product_id).first()


### PR DESCRIPTION

## 요약
- 유니티를 통해 자동입고 처리 시 타임스탬프가 서버 연결 시점으로만 찍히는 버그를 수정하였습니다.

<br><br>

## 참고 사항
- X
<br><br>

## 관련 이슈
- X

<br><br>
